### PR TITLE
Add dependency management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-tests := ./...
+TESTS ?= ./...
 
 .PHONY: all
 all: fmt test
@@ -7,17 +7,13 @@ all: fmt test
 fmt:
 	  go fmt ./...
 
-.PHONY: deps
-deps:
-	  go get ./...
-
-.PHONY: test-deps
-test-deps: deps
-	  go get -t ./...
+.PHONY: build
+build:
+	  go build ./...
 
 .PHONY: test
 test: test-unit
 
 .PHONY: test-unit
-test-unit: test-deps
-	  @set -a; go test $(tests) -run 'Unit'
+test-unit:
+	  go test $(TESTS) -run 'Unit'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 TESTS ?= ./...
 
+.EXPORT_ALL_VARIABLES:
+GO111MODULE = on
+
 .PHONY: all
 all: fmt test
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/companieshouse/htmlform
+
+go 1.12
+
+require github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 h1:WN9BUFbdyOsSH/XohnWpXOlq9NBD5sGAB2FciQMUEe8=
+github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/smartystreets/GoConvey/convey"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestMap(t *testing.T) {


### PR DESCRIPTION
Add the go.mod and go.sum files for dependency management.

Set environment variable required for using go modules. Go modules needs to be turned off for lint target to work.
```
GO111MODULE = on
```

Remove auto-update of dependencies. Dependencies should now be managed by the go.mod file.
```
go get
```

Further information can be found in the [Go dependency management guide](https://companieshouse.atlassian.net/wiki/x/AQB3SQ).